### PR TITLE
first layout to consider

### DIFF
--- a/jobs/migrations/0018_auto_20150204_1218.py
+++ b/jobs/migrations/0018_auto_20150204_1218.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0017_auto_20150202_2209'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='job',
+            name='expiration_date',
+            field=models.DateTimeField(help_text=b'Automatically is set 60 days from posting. You can override this.', null=True, blank=True),
+        ),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -65,9 +65,6 @@ class Job(models.Model):
             if self.ready_to_publish and not self.expiration_date:
                 self.expiration_date = self.published_date + timedelta(60)
                 self.save()
-            if self.ready_to_publish and self.expiration_date:
-                self.expiration_date = self.published_date + timedelta(60)
-                self.save()
 
 
     def __unicode__(self):

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -44,7 +44,7 @@ class Job(models.Model):
     ready_to_publish = models.BooleanField(default=False)
     published_date = models.DateTimeField(blank=True, null=True)
     created = models.DateTimeField(auto_now_add=True)
-    expiration_date = models.DateField(
+    expiration_date = models.DateTimeField(
         blank=True,
         null=True,
         help_text="Automatically is set 60 days from posting. You can override this."

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -84,9 +84,8 @@ class JobModelTests(TestCase):
         self.job.set_expiration_date()
         first_date = self.job.expiration_date
         self.assertTrue(self.job.expiration_date, "Job has no expiration date.")
-        time.sleep(1)
         self.job.publish()
         self.job.set_expiration_date()
         second_date = self.job.expiration_date
         self.assertTrue(self.job.expiration_date, "Job has no expiration date.")
-        self.assertTrue(second_date.second > first_date.second)
+        self.assertEqual(second_date.second, first_date.second)

--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -12,6 +12,9 @@
 
                 <ul>
                     <li><a href="{% url 'core:events' %}">Events</a></li>
+                    <li>
+                        <a href="{% url 'jobs:jobs' %}">Jobs</a>
+                    </li>
                     <li><a href="{% url 'core:stories' %}">Stories</a></li>
                     <li><a href="{% url 'core:resources' %}">Resources</a></li>
                     <li><a href="{% url 'core:organize' %}">Organize</a></li>

--- a/templates/jobs/jobs.html
+++ b/templates/jobs/jobs.html
@@ -8,41 +8,33 @@
         <section id="jobs">
             <div class="row">
                 <div class="col-md-12">
-                    <h2>
-                        Job offers
-                    </h2>
+                    <div class="page-header">
+                        <h2>
+                            Job offers and meet ups
+                        </h2>
+                        <div>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing
+                            elit. Mauris volutpat sem id fringilla cursus.
+                            Sed sit amet ornare enim. Morbi condimentum ultrices
+                            quam ac dictum. Etiam iaculis sapien velit, et 
+                            imperdiet est iaculis non. Morbi maximus auctor 
+                            nunc in pretium.
+                            Quisque molestie vitae enim quis suscipit. 
+                            In tempus bibendum diam eget eleifend.
+                        </div> <!--text div-->
+                    </div> <!--page-header-->
                 </div> <!--.col-md-12-->
             </div> <!--.row-->
 
             <div class="row">
-                <h3>Offers</h3>
-                <a class="btn" href="{% url 'jobs:job_new' %}">Add offer</a>
-                <table class="table table-striped">
-                    <thead>
-                        <th>Company</th>
-                        <th>Job title</th>
-                        <th>Posted</th>
-                    </thead>
-                    <tbody>
-                        {% for job in job_offers %}
-                            <tr>
-                                <td><a href="{{ job.company.website }}">{{ job.company }}</a></td>
-                                <td><a href="{% url 'jobs:job_details' id=job.id %}">{{ job.title }}</a></td>
-                                <td>{{ job.post_date }}</td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td>There are no job offers at this moment.</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-
-                <h3>Meetups</h3>
-                <p>Coming soon...</p>
-                
+                <h3><a href="#">Jobs</a></h3>
+                <a class="btn btn-block" href="{% url 'jobs:job_new' %}" style="margin-bottom:10px;">
+                    Add offer
+                </a>
+                {% include 'jobs/jobs.inc.html' %}
+                <h3><a href="#">Meet ups</a></h3>
+                {% include 'jobs/meetups.inc.html' %}
             </div> <!--.row-->
-
         </section>
 
     </div> <!--.container-->

--- a/templates/jobs/jobs.inc.html
+++ b/templates/jobs/jobs.inc.html
@@ -1,0 +1,39 @@
+<div class="panel panel-default">
+    <div class="panel-heading">
+        Current offers (<a href="">view more</a>)
+    </div>
+    <div class="panel-body">
+    <p>Some text here</p>
+    </div>
+
+    <table class="table table-striped">
+        <thead>
+            <th>Company</th>
+            <th>Job title</th>
+            <th>Location</th>
+            <th>Posted</th>
+        </thead>
+        <tbody>
+            {% for job in job_offers %}
+                <tr>
+                    <td>
+                        <a href="{{ job.company.website }}">
+                            {{ job.company }}
+                        </a>
+                    </td>
+                    <td>
+                        <a href="{% url 'jobs:job_details' id=job.id %}">
+                            {{ job.title }}
+                        </a>
+                    </td>
+                    <td>{{ job.city }} ({{ job.country }})</td>
+                    <td>{{ job.published_date }}</td>
+                </tr>
+                {% empty %}
+                    <tr>
+                        <td>There are no job offers at this moment.</td>
+                    </tr>
+                {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/templates/jobs/meetups.inc.html
+++ b/templates/jobs/meetups.inc.html
@@ -1,0 +1,102 @@
+<div class="row">
+    <div class="col-xs-4">
+        <div class="thumbnail">
+              <img src="http://aisp.bus.wisc.edu/wordpress/wp-content/uploads/2013/02/mis.jpeg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>We are all connected; To each other, biologically. To the earth, chemically. To the rest of the universe atomically.
+                I believe every human has a finite number of heartbeats. I don't intend to waste any of mine
+                Houston, Tranquillity Base here. The Eagle has landed.</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://www.bfoit.org/itp/images/Programming_Wordle.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>Hornswaggle prow yardarm reef galleon salmagundi square-rigged Davy Jones' Locker topmast cutlass. List Yellow Jack barque chandler Jack Ketch ho boatswain aft Nelsons folly Privateer. Take a caulk booty deadlights loot topmast Sink me spike poop deck scuppers barkadeer.</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://www.wroclaw.pl/files/wiadomosci/djanfgo-2.png" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>Shift club knuckle extra innings bleeder designated hitter left on base out foul line. Left fielder hot dog knuckle team rip, baltimore chop crooked number. Sport home at-bat peanuts reliever shift right field skipper. Curve stadium crooked number yankees first base manager on-base percentage.</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-4">
+        <div class="thumbnail">
+              <img src="https://sustainabilitymanagement2013.files.wordpress.com/2013/05/bad-engineers-arent-comfortable-with-multiple-forms-of-programming.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>These kind of things only happen for the first time once. It's OK to get Rib-grease on your face, because you're allowing people to see that you're proud of these ribs. Did you feel that? Look at me - I'm not out of breath anymore!  </p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://www.uleth.ca/artsci/sites/artsci/files/images/Photoxpress_1265172.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>Bavaria ipsum dolor sit amet Mongdratzal Biazelt wolln Diandldrahn. Almrausch Freibia so eam measi, i daad g’hupft wia gsprunga. Es i mog di fei ded a bravs ned jo mei is des schee, ned woar nimmds ma Breihaus. Wos is ma Wuascht hinter’m Berg san a no Leit helfgod Marterl Kaiwe um Godds wujn Wurscht? Es Brodzeid Spotzerl </p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://crossweb.pl/wp-content/uploads/2013/07/PYWAW.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>Webtwo ipsum dolor sit amet, eskobo chumby doostang bebo. Ngmoco zanga zlio yuntaa lijit vuvox zoosk yoono zooomr blyve greplin squidoo rovio imeem greplin fleck, oooj octopart zoodles orkut yoono lanyrd jibjab vimeo omgpop whrrl xobni geni meevee blippy. Jabber zappos napster disqus zoho reddit zillow zynga tumblr, reddit zoosk lanyrd</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-4">
+        <div class="thumbnail">
+              <img src="https://pbs.twimg.com/media/BshmhtcIcAAmR_E.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p> 
+                    All of a sudden cat goes crazy play time, yet sit in box, and find something else more interesting, inspect anything brought into the house, yet stare at the wall, play with food and get confused by dust. Have secret plans. Poop on grasses love to play with owner's hair tie. Spit up on light gray carpet instead of adjacent linoleum play time meow all night having their mate disturbing sleeping humans yet jump off balcony, onto stranger's head. Cat snacks</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://blog.twg.ca/wp-content/uploads/2014/07/Logo-Toronto-Nodejs.jpg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>Pitchfork High Life pork belly put a bird on it, occupy cardigan paleo. Vice pop-up cray, small batch fashion axe butcher cold-pressed artisan occupy hashtag quinoa Helvetica put a bird on it. Drinking vinegar dreamcatcher Blue Bottle synth. Literally gentrify meh Portland, skateboard migas chia kogi cliche. Plaid trust fund Thundercats skateboard</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+    <div class="col-xs-4">
+         <div class="thumbnail">
+              <img src="http://photos4.meetupstatic.com/photos/event/5/3/d/6/highres_361101462.jpeg" alt="...">
+              <div class="caption">
+                <h3>Meet up title</h3>
+                <p>They will lose the rest of their lives as they think about me and my life
+                    for the rest of their lives. So ... it's ... there's no ... again, bring me
+                    a challenge, somebody. Bring me a frickin' challenge. Because, you know ...
+                    it just ain't there. WINNING!</p>
+                <p><a href="#" class="btn btn-block" role="button">View more</a></p>
+              </div>
+         </div>
+    </div>
+</div>


### PR DESCRIPTION
I've done as we spoke, so everything is right now on one page (I didn't do any filters on job models, because I've assumed right now we just want to now how everything looks like). 
Personally I don't think it is a way to go, it is too much information on one page.
There is a problem with navbar - if I put there Jobs and Meetups, navbar lands below django girls logo. So for now it is named Jobs. We can use smaller font for everything and maybe then it will squeeze in. We can also find another (shorter) name for Jobs and Meetups. While doing a dropdown on Jobs it also breaks (EVENTS are too close to logo..). Still I am not sure dropdown should be on Jobs actually - maybe it should be on events? Wherever it would be, the font size should have to be smaller (or navbar will land below logo).
