### PR TITLE
Parent class for Jobs and Meetups

### DIFF
--- a/jobs/migrations/0027_auto_20150307_2208.py
+++ b/jobs/migrations/0027_auto_20150307_2208.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0026_auto_20150306_2003'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='job',
+            options={'ordering': ['-published_date']},
+        ),
+        migrations.AlterModelOptions(
+            name='meetup',
+            options={'ordering': ['-published_date']},
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='reviewer',
+            field=models.ForeignKey(related_name=b'jobs_job_related', on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='reviewer',
+            field=models.ForeignKey(related_name=b'jobs_meetup_related', on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -9,21 +9,14 @@ from django.conf import settings
 from core.models import User
 
 
-class Job(models.Model):
-    title = models.CharField(max_length=255)
-    company = models.CharField(max_length=255)
-    website = models.URLField(
-        help_text="Link to your offer or company website.",
-        blank=True,
-        null=True
-    )
-    contact_email = models.EmailField(max_length=255)
-    city = models.CharField(max_length=255)
-    country = CountryField()
-    description = models.TextField()
+class PublishFlowModel(models.Model):
+    """
+    An abstract class model that handles all logic related to publishing
+    an item that needs to be reviewed
+    """
     reviewer = models.ForeignKey(
         User,
-        related_name="jobs",
+        related_name="%(app_label)s_%(class)s_related",
         blank=True,
         null=True,
         on_delete=models.SET_NULL
@@ -42,7 +35,7 @@ class Job(models.Model):
     )
 
     class Meta:
-        unique_together = (("company", "title"),)
+        abstract = True
         ordering = ['-published_date']
 
     def publish(self):
@@ -52,11 +45,28 @@ class Job(models.Model):
             self.expiration_date = self.published_date + timedelta(60)
         self.save()
 
+
+class Job(PublishFlowModel):
+    title = models.CharField(max_length=255)
+    company = models.CharField(max_length=255)
+    website = models.URLField(
+        help_text="Link to your offer or company website.",
+        blank=True,
+        null=True
+    )
+    contact_email = models.EmailField(max_length=255)
+    city = models.CharField(max_length=255)
+    country = CountryField()
+    description = models.TextField()
+
+    class Meta(PublishFlowModel.Meta):
+        unique_together = (("company", "title"),)
+
     def __unicode__(self):
         return "{0}, {1}".format(self.title, self.company)
 
 
-class Meetup(models.Model):
+class Meetup(PublishFlowModel):
 
     MEETUP = 'MEET'
     CONFERENCE = 'CONF'
@@ -102,38 +112,9 @@ class Meetup(models.Model):
         help_text="If this is a recurring meetup/event, please enter a start date.\
             Date format: YYYY/MM/DD"
     )
-    reviewer = models.ForeignKey(
-        User,
-        related_name="meetups",
-        blank=True,
-        null=True,
-        on_delete=models.SET_NULL,
-    )
-    review_status = models.BooleanField(
-        default=False,
-        help_text="Check if reviewed",
-    )
-    reviewers_comment = models.TextField(blank=True, null=True,)
-    ready_to_publish = models.BooleanField(default=False)
-    published_date = models.DateTimeField(blank=True, null=True)
-    created = models.DateTimeField(auto_now_add=True)
-    expiration_date = models.DateField(
-        blank=True,
-        null=True,
-        help_text="Automatically is set 60 days from posting. You can "
-                  "override this.",
-    )
 
-    class Meta:
+    class Meta(PublishFlowModel.Meta):
         unique_together = (("title", "city"),)
-        ordering = ['-published_date']
-
-    def publish(self):
-        assert self.ready_to_publish
-        self.published_date = timezone.now()
-        if not self.expiration_date:
-            self.expiration_date = self.published_date + timedelta(60)
-        self.save()
 
     def __unicode__(self):
         return u"{0}, {1}".format(self.title, self.city)


### PR DESCRIPTION
I've created a parent class for the Jobs and Meetups models and I moved all the logic related to reviewing and publishing there. In that way, when we want to improve the publishing flow, we will need to do it only in one place. We will also be able to add another item requiring reviewing quite easily.
