### PR TITLE
Resolving #33 and #38, refactoring admin, first test in admin

### DIFF
--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -148,7 +148,7 @@ DEFAULT_FROM_EMAIL = "hello@djangogirls.org"
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = [
     '--with-coverage',
-    '--cover-package=core,applications',
+    '--cover-package=core,applications,jobs',
     '--with-progressive',
 ]
 

--- a/jobs/admin.py
+++ b/jobs/admin.py
@@ -217,6 +217,7 @@ class JobAdmin(PublishFlowModelAdmin):
     )
     readonly_fields = ('review_status', 'reviewer', 'published_date')
     list_display = ['title', 'company', 'reviewer', 'review_status', 'not_expired']
+    list_filter = ('reviewer', 'review_status')
     ordering = ['title']
     actions = [make_published, send_status_update_job_offer]
     formfield_overrides = {
@@ -238,6 +239,7 @@ class MeetupAdmin(PublishFlowModelAdmin):
     )
     readonly_fields = ('review_status', 'reviewer', 'published_date')
     list_display = ['title', 'city', 'reviewer', 'review_status', 'not_expired']
+    list_filter = ('reviewer', 'review_status')
     ordering = ['title']
     actions = [make_published, send_status_update_meetup]
     formfield_overrides = {

--- a/jobs/tests/test_admin.py
+++ b/jobs/tests/test_admin.py
@@ -1,0 +1,34 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from django.core.urlresolvers import reverse
+
+
+from model_mommy import mommy
+
+from core.models import User
+from jobs.models import Job, Meetup
+
+
+class JobAdminTest(TestCase):
+    """Tests for custom methods of JobAdmin model."""
+
+    def setUp(self):
+        self.job_open = mommy.make(
+            Job,
+            review_status=Job.OPEN,
+        )
+        self.admin_user = User.objects.create_superuser('myemail@test.com', 'example')
+        self.client.login(username=self.admin_user.email, password='example')
+
+    def test_assigning_job_reviewer_to_open_post(self):
+        assign_reviewer_url = reverse('admin:assign_job_reviewer', args=[self.job_open.id])
+        response = self.client.get(assign_reviewer_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        # TODO: assert model field
+        self.assertIn("Under review", str(response.content))
+
+    def tearDown(self):
+        self.job_open.delete()
+        self.admin_user.delete()

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -86,23 +86,23 @@ class JobModelTests(TestCase):
 
     def test_reject_for_jobs_under_review(self):
         """Tests the reject method for jobs in the UNDER_REVIEW state"""
-        self.job_under_review.reject(option='job')
+        self.job_under_review.reject()
         self.assertTrue(self.job_under_review.review_status == Job.REJECTED)
 
     def test_reject_for_jobs_ready_to_publish(self):
         """Tests the reject method for jobs in the READY_TO_PUBLISHED state"""
-        self.job_ready_no_exp_date.reject(option='job')
+        self.job_ready_no_exp_date.reject()
         self.assertTrue(self.job_ready_no_exp_date.review_status == Job.REJECTED)
 
     def test_reject_for_jobs_published(self):
         """Tests the reject method for jobs in the PUBLISHED state"""
-        self.job_published.reject(option='job')
+        self.job_published.reject()
         self.assertTrue(self.job_published.review_status == Job.REJECTED)
         self.assertFalse(self.job_published.published_date)
 
     def test_reject_for_jobs_in_wrong_state(self):
         """Tests the reject method for jobs not in the wrong state"""
-        self.assertRaises(AssertionError, self.job_open.reject, option='job_offer')
+        self.assertRaises(AssertionError, self.job_open.reject)
 
     def test_restore_for_jobs_rejected(self):
         """Tests the restore method for jobs in the REJECTED state"""
@@ -117,11 +117,11 @@ class JobModelTests(TestCase):
     def test_publish_not_ready_to_publish(self):
         """Attempts to publish jobs which are not in the READY_TO_PUBLISH state,
         it should results in an assertion error"""
-        self.assertRaises(AssertionError,  self.job_open.publish, option='job_offer')
+        self.assertRaises(AssertionError,  self.job_open.publish)
 
     def test_expiration_date_default_value(self):
         """Tests if default value is 60 days from now."""
-        self.job_ready_no_exp_date.publish(option='job')
+        self.job_ready_no_exp_date.publish()
         self.assertTrue(self.job_ready_no_exp_date.published_date)
         self.assertAlmostEqual(
             self.job_ready_no_exp_date.published_date,
@@ -134,7 +134,7 @@ class JobModelTests(TestCase):
 
     def test_publish_with_custom_expiration_date(self):
         """Tests the publish method with custom expiration date set"""
-        self.job_ready_future_exp_date.publish(option='job_offer')
+        self.job_ready_future_exp_date.publish()
         self.assertEqual(
             self.job_ready_future_exp_date.expiration_date,
             self.future_date
@@ -143,9 +143,9 @@ class JobModelTests(TestCase):
     def test_publish_twice_in_a_row(self):
         """It is not possible to publish a job offer twice"""
         self.assertFalse(self.job_ready_no_exp_date.published_date)
-        self.job_ready_no_exp_date.publish(option='job_offer')
+        self.job_ready_no_exp_date.publish()
         self.assertTrue(self.job_ready_no_exp_date.published_date, "Job has no published date.")
-        self.assertRaises(AssertionError, self.job_ready_no_exp_date.publish, option='job_offer')
+        self.assertRaises(AssertionError, self.job_ready_no_exp_date.publish)
 
 
 class MeetupModelTests(TestCase):
@@ -169,11 +169,11 @@ class MeetupModelTests(TestCase):
     def test_publish_without_ready_to_publish(self):
         """Attempts to publish meetups with ready_to_published=False
         should results in an assertion error"""
-        self.assertRaises(AssertionError,  self.meetup_not_ready.publish, option='meetup')
+        self.assertRaises(AssertionError,  self.meetup_not_ready.publish)
 
     def test_publish_with_default_expiration_date(self):
         """Tests the publish method with no expiration date set"""
-        self.meetup_ready_no_exp_date.publish(option='meetup')
+        self.meetup_ready_no_exp_date.publish()
         self.assertTrue(self.meetup_ready_no_exp_date.published_date)
         self.assertAlmostEqual(
             self.meetup_ready_no_exp_date.published_date,
@@ -186,7 +186,7 @@ class MeetupModelTests(TestCase):
 
     def test_publish_with_custom_expiration_date(self):
         """Tests the publish method with custom expiration date set"""
-        self.meetup_ready_future_exp_date.publish(option='meetup')
+        self.meetup_ready_future_exp_date.publish()
         self.assertEqual(
             self.meetup_ready_future_exp_date.expiration_date,
             self.future_date

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -1,6 +1,9 @@
 button.save {
   margin-top: 10px;
 }
+.white {
+  color: #fff;
+}
 #community {
   padding: 30px 0 0 0;
 }

--- a/static/css/community.styl
+++ b/static/css/community.styl
@@ -1,6 +1,9 @@
 button.save
     margin-top 10px
 
+.white
+    color: white
+
 #community
     padding: 30px 0 0 0
 

--- a/templates/includes/_jobs.html
+++ b/templates/includes/_jobs.html
@@ -2,6 +2,7 @@
     <div class="thumbnail">
         <p class="title"><a href="{% url 'jobs:job_details' id=job.id %}">{{ job.title }}</a></p>
 
+        <p><strong>For:</strong> {{ job.company }}</p>
         <p><strong>Where:</strong> {{ job.cities }}</p>
     </div>
 </div>

--- a/templates/jobs/job_details.html
+++ b/templates/jobs/job_details.html
@@ -7,36 +7,45 @@
     <section id="job_details">
         <div class="container">
             <div class="row">
-                <ol class="breadcrumb">
-                    <li><a href="{% url 'core:index' %}">Home</a></li>
-                    <li><a href="{% url 'jobs:main' %}">Community</a></li>
-                    <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
-                    <li class="active">{{ job.title }}</li>
-                </ol>
+
                 <div class="col-md-12">
-                    <h2>{{ job.title }} 
-                        <small>
-                            at {{ job.company }}
-                        </small>
-                    </h2>
-                    <p class="text-muted">Published on {{ job.published_date|date:'d F Y' }}</p>
-                    <table class="table" id="job-table">
-                        <tr>
-                            <th>Remote work</th>
-                            <td>{{ job.remote_work|yesno }}</td>
-                        </tr>
-                        <tr>
-                            <th>Relocation offered</th>
-                            <td>{{ job.relocation|yesno }}</td>
-                        </tr>
-                    </table>
-                    <h3>Place:</h3>
-                    <p>{{ job.cities }}, {{ job.country }}</p>
-                    <h3>Description:</h3>
-                    <p>{{ job.description|safe }}</p>
-                    <h3>Contact and more information:</h3>
-                        <p>{{ job.contact_email }}</p>
-                        <p><a href="{{ job.website }}">view website</a></p>
+                    <ol class="breadcrumb">
+                        <li><a href="{% url 'core:index' %}">Home</a></li>
+                        <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                        <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
+                        <li class="active">{{ job.title }}</li>
+                    </ol>
+                    <div class="panel panel-feature-blue">
+                        <div class="panel-heading">
+                            <h2>{{ job.title }}
+                                <small>
+                                    at <span class="white">{{ job.company }}</span>
+                                </small>
+                            </h2>
+                        </div>
+                        <div class="panel-body">
+                            <div class="text-muted pull-right">
+                                <p>Published on {{ job.published_date|date:'d F Y' }}</p>
+                                <table class="table" id="job-table">
+                                    <tr>
+                                        <td>Remote work</td>
+                                        <td><strong>{{ job.remote_work|yesno }}</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Relocation offered</td>
+                                        <td><strong>{{ job.relocation|yesno }}</strong></td>
+                                    </tr>
+                                </table>
+                            </div>
+                            <h3>Where</h3>
+                            <p>{{ job.cities }}, {{ job.country }}</p>
+                            <h3>Description</h3>
+                            <p>{{ job.description|safe }}</p>
+                            <h3>Contact</h3>
+                            <p>{{ job.contact_email }}</p>
+                            <p><a href="{{ job.website }}">view website</a></p>
+                        </div>
+                    </div>
 
                 </div> <!--.col-md-12-->
             </div> <!--.row-->

--- a/templates/jobs/job_details.html
+++ b/templates/jobs/job_details.html
@@ -33,12 +33,7 @@
                     <h3>Place:</h3>
                     <p>{{ job.cities }}, {{ job.country }}</p>
                     <h3>Description:</h3>
-                    {% if job.description %}
-                        <p>{{ job.description|safe }}</p>
-                    {% else %}
-                        <!--For testing purposes only! Delete before deploying!-->
-                        <p>{% lorem 5 p %}</p>
-                    {% endif %}
+                    <p>{{ job.description|safe }}</p>
                     <h3>Contact and more information:</h3>
                         <p>{{ job.contact_email }}</p>
                         <p><a href="{{ job.website }}">view website</a></p>

--- a/templates/jobs/job_edit.html
+++ b/templates/jobs/job_edit.html
@@ -16,18 +16,33 @@
             <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
             <li class="active">Add job offer</li>
         </ol>
+        <div>
+            <h2>
+                Add job offer
+            </h2>
+            <p>
+                Adding a job offer on Django Girls website is free. Yay!
+                Our website is visited monthly by XXX beginner developers and we can help you reach them with your offer.
+                However, all the offers listed here need to meet following requirements:
+            </p>
+            <ul>
+                <li>The offer needs to be beginner-friendly - no experience required.</li>
+                <li>The offer must not discriminate any gender.</li>
+            </ul>
+            <p>
+                You need to show us that you care about improving diversity.
+                We don’t want to recommend to our friends that they work in places that don’t value this.
+            </p>
+            <p>
+                Publishing an offer here is free, however, Django Girls is a non-profit organisation
+                with a mission to show more women how amazing programming is. It’d be greatly appreciated if you could
+                consider donating money to us to help us make a bigger impact.
+                You can do so via <a href="https://www.patreon.com/djangogirls">Patreon</a>.
+            </p>
+        </div>
             <div class="panel panel-feature-blue">
                 <div class="panel-heading">
                     <h2>New offer</h2>
-                    <p>
-                        Adding a job offer on Django Girls website is free. Yay! Our website is visited monthly by XXX beginner developers and we can help you reach them with your offer. However, all the offers listed here need to meet following requirements:
-                        <ul>
-                            <li>The offer needs to be beginner-friendly - no experience required.</li>
-                            <li>The offer must not discriminate any gender.</li>
-                        </ul>
-                        You need to show us that you care about improving diversity. We don’t want to recommend to our friends that they work in places that don’t value this.
-                        Publishing an offer here is free, however, Django Girls is a non-profit organisation with a mission to show more women how amazing programming is. It’d be greatly appreciated if you could consider donating money to us to help us make a bigger impact. You can do so via <a href="https://www.patreon.com/djangogirls">Patreon</a>.
-                    </p>
                 </div>
                 <div class="panel-body">
                     <form method="POST" class="job-form">

--- a/templates/jobs/job_edit.html
+++ b/templates/jobs/job_edit.html
@@ -22,7 +22,7 @@
             </h2>
             <p>
                 Adding a job offer on Django Girls website is free. Yay!
-                Our website is visited monthly by XXX beginner developers and we can help you reach them with your offer.
+                Our website is visited by many enthusiastic beginner developers and we can help you reach them with your offer.
                 However, all the offers listed here need to meet following requirements:
             </p>
             <ul>

--- a/templates/jobs/jobs.html
+++ b/templates/jobs/jobs.html
@@ -11,8 +11,16 @@
                         Job offers
                     </h2>
                     <p>
-                       Working as a software developer is a great way to become one. There are lots of companies out there who are hiring, but how can you tell which ones are good? We have talked to a lot of them and here you can find offers from companies who hire beginners and want to train them. They’re not targeting women only, but they do care about diversity in a workplace. We trust they do the right things.
-                        On this page we only list offers that require no experience, from companies who want to hire beginners and care about diversity.
+                       Working as a software developer is a great way to become one.
+                       There are lots of companies out there who are hiring,
+                       but how can you tell which ones are good? We have talked
+                       to a lot of them and here you can find offers from companies
+                       who hire beginners and want to train them. They’re not targeting women only,
+                       but they do care about diversity in a workplace. We trust they do the right things.
+                    </p>
+                    <p>
+                       On this page we only list offers that require no experience, from companies who
+                       want to hire beginners and care about diversity.
                     </p>
                 </div> <!--.col-md-12-->
             </div> <!--.row-->

--- a/templates/jobs/jobs.html
+++ b/templates/jobs/jobs.html
@@ -7,6 +7,11 @@
         <section id="jobs">
             <div class="row">
                 <div class="col-md-12">
+                    <ol class="breadcrumb">
+                        <li><a href="{% url 'core:index' %}">Home</a></li>
+                        <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                        <li class="active">Job offers</li>
+                    </ol>
                     <h2>
                         Job offers
                     </h2>
@@ -22,13 +27,13 @@
                        On this page we only list offers that require no experience, from companies who
                        want to hire beginners and care about diversity.
                     </p>
+                    <a class="btn btn-blue" href="{% url 'jobs:job_new' %}">Add offer</a>
                 </div> <!--.col-md-12-->
             </div> <!--.row-->
 
             <div class="row">
                 <div class="col-md-12">
                     <h3>Offers</h3>
-                    <a class="btn btn-blue" href="{% url 'jobs:job_new' %}">Add offer</a>
                     <table class="table table-striped">
                         <thead>
                             <th>Company</th>

--- a/templates/jobs/main.html
+++ b/templates/jobs/main.html
@@ -22,7 +22,11 @@
 <div class="container">
     <section id="community">
         <div class="row">
-            <div class="col-md-9">
+            <div class="col-md-12">
+                 <ol class="breadcrumb">
+                    <li><a href="{% url 'core:index' %}">Home</a></li>
+                    <li class="active">Community</li>
+                </ol>
                 <h2>Django Girls Community</h2>
 
                 <p>If you find yourself on this page, you probably recently completed the Django Girls tutorial — either at one of our workshops, at an event in your city or at home on your own.</p>
@@ -35,7 +39,7 @@
             <div class="col-md-6">
                 <div class="panel panel-feature-blue">
                     <div class="panel-heading">
-                        Jobs
+                        <h3>Jobs</h3>
                     </div>
                     <div class="panel-body">
                         <p>
@@ -47,24 +51,19 @@
                         <h4>Recent offers:</h4>
                         {% if job_offers %}
                             {% for job in job_offers %}
-                            <div class="col-md-6 event">
                                 {% include 'includes/_jobs.html' with job=job %}
-                            </div>
-                        
                             {% endfor %}
                         {% else %}
                             <p>No job offers yet...</p>
                         {% endif %}
-                        <div class="col-md-12">
                             <a class="btn btn-blue btn-block" href="{% url 'jobs:jobs' %}">More...</a>
-                        </div>
                     </div>
                 </div>
             </div>
             <div class="col-md-6">
                 <div class="panel panel-feature-orange">
                     <div class="panel-heading">
-                        Meetups
+                        <h3>Meetups</h3>
                     </div>
                     <div class="panel-body">
                         <p>
@@ -79,16 +78,12 @@
                         <h4>Recent meetups:</h4>
                         {% if meetup_list %}
                             {% for meetup in meetup_list %}
-                            <div class="col-md-12 event">
                                 {% include 'includes/_meetups.html' with meetup=meetup %}
-                            </div>
                             {% endfor %}
                         {% else %}
                             <p>No meetups yet...</p>
                         {% endif %}
-                        <div class="col-md-12">
                             <a class="btn btn-block" href="{% url 'jobs:meetups' %}">More...</a>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/jobs/meetup_details.html
+++ b/templates/jobs/meetup_details.html
@@ -7,35 +7,54 @@
 <section id="meetup_details">
     <div class="container">
         <div class="row">
-           <ol class="breadcrumb">
-                <li><a href="{% url 'core:index' %}">Home</a></li>
-                <li><a href="{% url 'jobs:main' %}">Community</a></li>
-                <li><a href="{% url 'jobs:meetups' %}">Meet ups</a></li>
-                <li class="active">{{ meetup.title }}</li>
-            </ol>
             <div class="col-md-12">
-                <h2>
-                    {% if meetup.website %}
-                        <a href="{{ meetup.website }}">{{ meetup.title }}</a>
-                    {% else %}
-                        {{ meetup.title }}
-                    {% endif %}
-                    <small>in {{ meetup.city }}, {{ meetup.country }}</small>
-                </h2>
-                <h4>Date and time:</h4>
-                <p>begins: {{ meetup.meetup_start_date|date:"l, d F Y, f A" }}</p>
-                    {% if meetup.meetup_end_date %}
-                        <p>ends: {{ meetup.meetup_end_date|date:"l, d F Y, f A" }}</p>
-                    {% endif %}
-                {% if meetup.company %}
-                    <h4>Organised by:</h4>
-                    <p>{{ meetup.company }}</p>
-                {% endif %}
-                <h4>Description:</h4>
-                <p>{{ meetup.description|safe }}</p>
-                {% if meetup.is_recurring %}
-                    <p>This is a recurring event</p>
-                {% endif %}
+
+                <ol class="breadcrumb">
+                    <li><a href="{% url 'core:index' %}">Home</a></li>
+                    <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                    <li><a href="{% url 'jobs:meetups' %}">Meetups</a></li>
+                    <li class="active">{{ meetup.title }}</li>
+                </ol>
+
+                <div class="panel panel-feature-orange">
+                    <div class="panel-heading">
+                        <h2>
+                            {% if meetup.website %}
+                                <a href="{{ meetup.website }}">{{ meetup.title }}</a>
+                            {% else %}
+                                {{ meetup.title }}
+                            {% endif %}
+                            <small>in <span class="white">{{ meetup.city }}, {{ meetup.country }}</span></small>
+                        </h2>
+                    </div>
+                    <div class="panel-body">
+                        <div class="text-muted pull-right">
+                            <p>Published on {{ meetup.published_date|date:'d F Y' }}</p>
+                        </div>
+                        <h3>When</h3>
+                        <p>
+                            <strong>Begins:</strong> {{ meetup.meetup_start_date|date:"l, d F Y, f A" }}
+                        </p>
+                            {% if meetup.meetup_end_date %}
+                                <p>
+                                    <strong>Ends:</strong> {{ meetup.meetup_end_date|date:"l, d F Y, f A" }}
+                                </p>
+                            {% endif %}
+                        <h3>Description</h3>
+                        <p>{{ meetup.description|safe }}</p>
+                        {% if meetup.is_recurring %}
+                            <p>This is a recurring event</p>
+                        {% endif %}
+                        {% if meetup.organisation %}
+                            <h3>Organised by</h3>
+                            <p>{{ meetup.organisation }}</p>
+                        {% endif %}
+                        <h3>Contact</h3>
+                        <p>{{ meetup.contact_email }}</p>
+                    </div>
+                </div>
+
+
             </div> <!--.col-md-12-->
         </div> <!--.row-->
     </div> <!--.container-->

--- a/templates/jobs/meetup_details.html
+++ b/templates/jobs/meetup_details.html
@@ -32,12 +32,7 @@
                     <p>{{ meetup.company }}</p>
                 {% endif %}
                 <h4>Description:</h4>
-                {% if meetup.description %}
-                    <p>{{ meetup.description|safe }}</p>
-                {% else %}
-                    <!--For testing purposes only! Delete before deploying!-->
-                    <p>{% lorem 5 p %}</p>
-                {% endif %}
+                <p>{{ meetup.description|safe }}</p>
                 {% if meetup.is_recurring %}
                     <p>This is a recurring event</p>
                 {% endif %}

--- a/templates/jobs/meetup_edit.html
+++ b/templates/jobs/meetup_edit.html
@@ -26,9 +26,9 @@
                     Add meetup
                 </h2>
                 <p>
-                    Adding a meetup on Django Girls website is free. Our website is visited monthly
-                    by XXX beginner developers and we can help you reach them. However, all the meetups
-                    listed here need to meet following requirements:
+                    Adding a meetup on Django Girls website is free. Our website is visited
+                    by many enthusiastic beginner developers and we can help you reach them.
+                    However, all the meetups listed here need to meet following requirements:
                 </p>
                 <ul>
                     <li>The meetup needs to be beginner-friendly.</li>

--- a/templates/jobs/meetup_edit.html
+++ b/templates/jobs/meetup_edit.html
@@ -21,15 +21,24 @@
                 <li><a href="{% url 'jobs:meetups' %}">Meetups</a></li>
                 <li class="active">Add meetup</li>
             </ol>
+            <div>
+                <h2>
+                    Add meetup
+                </h2>
+                <p>
+                    Adding a meetup on Django Girls website is free. Our website is visited monthly
+                    by XXX beginner developers and we can help you reach them. However, all the meetups
+                    listed here need to meet following requirements:
+                </p>
+                <ul>
+                    <li>The meetup needs to be beginner-friendly.</li>
+                    <li>The meetup needs to have a published and enforced Code of Conduct.</li>
+                </ul>
+                <p>Yay!</p>
+            </div>
             <div class="panel panel-feature-orange">
                 <div class="panel-heading">
                     <h1>New meetup</h1>
-                        <p>Adding a meetup on Django Girls website is free. Our website is visited monthly by XXX beginner developers and we can help you reach them. However, all the meetups listed here need to meet following requirements:</p>
-                        <ul>
-                            <li>The meetup needs to be beginner-friendly.</li>
-                            <li>The meetup needs to have a published and enforced Code of Conduct.</li>
-                        </ul>
-                        <p>Yay!</p>
                 </div>
                 <div class="panel-body">
                     <form method="POST" class="job-form">

--- a/templates/jobs/meetup_edit.html
+++ b/templates/jobs/meetup_edit.html
@@ -38,7 +38,7 @@
             </div>
             <div class="panel panel-feature-orange">
                 <div class="panel-heading">
-                    <h1>New meetup</h1>
+                    <h2>New meetup</h2>
                 </div>
                 <div class="panel-body">
                     <form method="POST" class="job-form">

--- a/templates/jobs/meetups.html
+++ b/templates/jobs/meetups.html
@@ -6,16 +6,29 @@
     <div class="container">
 
         <section id="meetups">
+            <ol class="breadcrumb">
+                <li><a href="{% url 'core:index' %}">Home</a></li>
+                <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                <li class="active">Meetups</li>
+            </ol>
         {% include 'includes/_info_messages.html' %}
-        <p>
-            Did you know that Dori, Django Girls alumni from our first event in Berlin, got a job because she gave a talk about Django Girls at her local Django meetup in Budapest? That’s why your local meetups and user groups can help you make a career in tech. 
-        </p>
-        <p>
-            Here you can find (or add!) meetups in your city where programmers meet to talk about technology. They all have published Code of Conduct, we checked! 
-        </p>
-        <p>
-            On this page we only list meetups and groups that are friendly to beginners and have a published Code of Conduct. If you see a meetup that doesn’t meet the requirement, please do let us know. We care about you.
-        </p>
+            <h2>
+                Meetups
+            </h2>
+            <p>
+                Did you know that Dori, Django Girls alumni from our first event in Berlin,
+                got a job because she gave a talk about Django Girls at her local Django meetup in Budapest?
+                That’s why your local meetups and user groups can help you make a career in tech.
+            </p>
+            <p>
+                Here you can find (or add!) meetups in your city where programmers meet to talk about technology.
+                They all have published Code of Conduct, we checked!
+            </p>
+            <p>
+                On this page we only list meetups and groups that are friendly to beginners
+                and have a published Code of Conduct. If you see a meetup that doesn’t meet the requirement,
+                please do let us know. We care about you.
+            </p>
         <a class="btn" href="{% url 'jobs:meetup_new' %}">Add meetup</a>
         </section>
         <div class="row">


### PR DESCRIPTION
In this commit, I've made the following changes:
- Removed the lorem ipsum tags from meetup_details and job_details
- Moved the intro text in job_edit and meetup_edit about the form panel
- Added the heading to job_edit and meetup_edit
- Added 'jobs' to coverage
- Refactored the admin models - I've created the base PublishFlowModelAdmin model which contains all the flow logic. It's quite similar to  a solution for jobs.models.py
- Refactored jobs.models.py to use _meta.model_name instead of a hard-coded string
- Resolved #33 - it is still possible to re-publish an expired post but the expiration_date is reset
- Added the first test for the jobs admin site
