### PR TITLE
Correct settings import in community_email.py

### DIFF
--- a/jobs/community_mails.py
+++ b/jobs/community_mails.py
@@ -1,6 +1,5 @@
 from smtplib import SMTPException
 from django.core.mail import send_mail
-
 from django.conf import settings
 
 


### PR DESCRIPTION
Instead of importing from a specific settings file, we should import settings from django.conf, and then use settings.JOBS_EMAIL_USER etc to refer to the settings variables.  This means that if we run the application using a different settings file, the variables will still be available.
