### PR TITLE
Added message_to_organisation field and more admin tests

### DIFF
--- a/jobs/admin.py
+++ b/jobs/admin.py
@@ -17,6 +17,12 @@ def make_published(modeladmin, request, queryset):
     for item in queryset:
         if item.review_status == PublishFlowModel.READY_TO_PUBLISH:
             item.publish()
+        else:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                "{0} couldn't be published.".format(item.title)
+            )
 make_published.short_description = "Publish selected items"
 
 
@@ -111,7 +117,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to assign reviewer: post is in a wrong state."
+            )
 
     def unassign_reviewer(self, request, id):
         try:
@@ -124,7 +132,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to unassign reviewer: post is in a wrong state."
+            )
 
     def accept(self, request, id):
         try:
@@ -137,7 +147,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to accept post: post is in a wrong state."
+            )
 
     def reject(self, request, id):
         try:
@@ -152,7 +164,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to reject reviewer: post is in a wrong state."
+            )
 
     def restore(self, request, id):
         try:
@@ -165,7 +179,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to restore post: post is in a wrong state."
+            )
 
     def publish(self, request, id):
         try:
@@ -180,7 +196,9 @@ class PublishFlowModelAdmin(admin.ModelAdmin):
             )
             return redirect('/admin/jobs/%s/%s/' % (self.get_print_name(), id))
         except AssertionError:
-            return HttpResponseBadRequest("Post in a wrong state")
+            return HttpResponseBadRequest(
+                "It's not possible to publish post: post is in a wrong state."
+            )
 
 
 class JobAdmin(PublishFlowModelAdmin):

--- a/jobs/migrations/0004_auto_20150712_1803.py
+++ b/jobs/migrations/0004_auto_20150712_1803.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0003_auto_20150510_1707'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='job',
+            name='reviewers_comment',
+        ),
+        migrations.RemoveField(
+            model_name='meetup',
+            name='reviewers_comment',
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='internal_comment',
+            field=models.TextField(null=True, blank=True, help_text="Write you comments here. They won't be sent to the company/organisation."),
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='message_to_organisation',
+            field=models.TextField(null=True, blank=True, help_text='Write your message to the company/organisation here.'),
+        ),
+        migrations.AddField(
+            model_name='meetup',
+            name='internal_comment',
+            field=models.TextField(null=True, blank=True, help_text="Write you comments here. They won't be sent to the company/organisation."),
+        ),
+        migrations.AddField(
+            model_name='meetup',
+            name='message_to_organisation',
+            field=models.TextField(null=True, blank=True, help_text='Write your message to the company/organisation here.'),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='expiration_date',
+            field=models.DateField(null=True, blank=True, help_text='Automatically is set 60 days from posting. You can override this.'),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='review_status',
+            field=models.CharField(choices=[('OPN', 'Open'), ('URE', 'Under review'), ('RTP', 'Ready to publish'), ('REJ', 'Rejected'), ('PUB', 'Published')], max_length=3, default='OPN'),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='website',
+            field=models.URLField(null=True, blank=True, help_text='Link to your offer or company website.'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='expiration_date',
+            field=models.DateField(null=True, blank=True, help_text='Automatically is set 60 days from posting. You can override this.'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='meetup_end_date',
+            field=models.DateTimeField(null=True, blank=True, help_text='Date format: YYYY-MM-DD'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='meetup_start_date',
+            field=models.DateTimeField(null=True, help_text='If this is a recurring meetup/event, please enter a start date.            Date format: YYYY-MM-DD'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='meetup_type',
+            field=models.CharField(choices=[('MEET', 'meetup'), ('CONF', 'conference'), ('WORK', 'workshop')], max_length=4, default='MEET'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='recurrence',
+            field=models.CharField(null=True, blank=True, max_length=255, help_text='Provide details of recurrence if applicable.'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='review_status',
+            field=models.CharField(choices=[('OPN', 'Open'), ('URE', 'Under review'), ('RTP', 'Ready to publish'), ('REJ', 'Rejected'), ('PUB', 'Published')], max_length=3, default='OPN'),
+        ),
+        migrations.AlterField(
+            model_name='meetup',
+            name='website',
+            field=models.URLField(null=True, blank=True, help_text='Link to your meetup or organisation website.'),
+        ),
+    ]

--- a/jobs/migrations/0005_merge.py
+++ b/jobs/migrations/0005_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0004_auto_20150707_1518'),
+        ('jobs', '0004_auto_20150712_1803'),
+    ]
+
+    operations = [
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -19,8 +19,11 @@ class PublishFlowManager(models.Manager):
 
     def get_queryset(self):
         now = timezone.now().date().strftime("%Y-%m-%d")
+        # 1=1 to ensure compatibility between different DBs
+        # this is to fix the error:
+        # 'COALESCE types boolean and integer cannot be matched'
         return super(PublishFlowManager, self).get_queryset().extra(
-            select={'not_expired': "coalesce(expiration_date > '%s', 1)" % now})
+            select={'not_expired': "coalesce(expiration_date > '%s', 1=1)" % now})
 
 
 class VisiblePublishFlowManager(PublishFlowManager):

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -58,7 +58,17 @@ class PublishFlowModel(models.Model):
         on_delete=models.SET_NULL
     )
     review_status = models.CharField(max_length=3, choices=STATUSES, default=OPEN)
-    reviewers_comment = models.TextField(blank=True, null=True)
+    message_to_organisation = models.TextField(
+        blank=True,
+        null=True,
+        help_text="Write your message to the company/organisation here."
+    )
+    internal_comment = models.TextField(
+        blank=True,
+        null=True,
+        help_text="Write you comments here. They won't be sent to "
+                  "the company/organisation."
+    )
     published_date = models.DateTimeField(blank=True, null=True)
     created = models.DateTimeField(auto_now_add=True)
     expiration_date = models.DateField(
@@ -105,7 +115,7 @@ class PublishFlowModel(models.Model):
         context = Context({
                     'status': self.get_review_status_display(),
                     'option': model_name,
-                    'reviewers_comment': self.reviewers_comment,
+                    'message_to_organisation': self.message_to_organisation,
                 })
         message_plain = get_template(
             'jobs/email_templates/status.txt').render(context)
@@ -148,7 +158,7 @@ class PublishFlowModel(models.Model):
         context = Context({
                     'status': self.get_review_status_display(),
                     'option': model_name,
-                    'reviewers_comment': self.reviewers_comment,
+                    'message_to_organisation': self.message_to_organisation,
                 })
         message_plain = get_template(
             'jobs/email_templates/status.txt').render(context)

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -69,7 +69,7 @@ class PublishFlowModel(models.Model):
     internal_comment = models.TextField(
         blank=True,
         null=True,
-        help_text="Write you comments here. They won't be sent to "
+        help_text="Write your comments here. They won't be sent to "
                   "the company/organisation."
     )
     published_date = models.DateTimeField(blank=True, null=True)

--- a/jobs/tests/test_admin.py
+++ b/jobs/tests/test_admin.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 from django.core.urlresolvers import reverse
+from django.core import mail
 
 
 from model_mommy import mommy
@@ -15,20 +16,151 @@ class JobAdminTest(TestCase):
     """Tests for custom methods of JobAdmin model."""
 
     def setUp(self):
+        self.admin_user = User.objects.create_superuser('myemail@test.com', 'example')
+        self.future_date = timezone.now().date() + timedelta(days=10)
         self.job_open = mommy.make(
             Job,
             review_status=Job.OPEN,
         )
-        self.admin_user = User.objects.create_superuser('myemail@test.com', 'example')
+        self.job_under_review = mommy.make(
+            Job,
+            review_status=Job.UNDER_REVIEW,
+            reviewer=self.admin_user,
+        )
+        self.job_ready_to_publish = mommy.make(
+            Job,
+            review_status=Job.READY_TO_PUBLISH,
+            reviewer=self.admin_user,
+        )
+        self.job_published = mommy.make(
+            Job,
+            review_status=Job.PUBLISHED,
+            reviewer=self.admin_user,
+            published_date=timezone.now(),
+            expiration_date=self.future_date,
+        )
+        self.job_rejected = mommy.make(
+            Job,
+            review_status=Job.REJECTED,
+            reviewer=self.admin_user,
+        )
         self.client.login(username=self.admin_user.email, password='example')
 
     def test_assigning_job_reviewer_to_open_post(self):
-        assign_reviewer_url = reverse('admin:assign_job_reviewer', args=[self.job_open.id])
+        assign_reviewer_url = reverse(
+            'admin:assign_job_reviewer',
+            args=[self.job_open.id]
+        )
         response = self.client.get(assign_reviewer_url, follow=True)
         self.assertEqual(response.status_code, 200)
-        # TODO: assert model field
+        self.job_open.refresh_from_db()
         self.assertIn("Under review", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_open.review_status, Job.UNDER_REVIEW)
+
+    def test_assigning_job_reviewer_to_under_review_post(self):
+        assign_reviewer_url = reverse(
+            'admin:assign_job_reviewer',
+            args=[self.job_under_review.id]
+        )
+        response = self.client.get(assign_reviewer_url, follow=True)
+        self.assertEqual(response.status_code, 400)
+
+    def test_unassigning_job_reviewer_from_under_review_post(self):
+        unassign_reviewer_url = reverse(
+            'admin:unassign_job_reviewer',
+            args=[self.job_under_review.id]
+        )
+        response = self.client.get(unassign_reviewer_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_under_review.refresh_from_db()
+        self.assertIn("Open", str(response.content))
+        self.assertIn("None", str(response.content))
+        self.assertEqual(self.job_under_review.review_status, Job.OPEN)
+
+    def test_accept_job_for_under_review_post(self):
+        accept_url = reverse(
+            'admin:accept_job',
+            args=[self.job_under_review.id]
+        )
+        response = self.client.get(accept_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_under_review.refresh_from_db()
+        self.assertIn("Ready to publish", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_under_review.review_status, Job.READY_TO_PUBLISH)
+
+    def test_reject_job_for_under_review_post(self):
+        reject_url = reverse(
+            'admin:reject_job',
+            args=[self.job_under_review.id]
+        )
+        response = self.client.get(reject_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_under_review.refresh_from_db()
+        self.assertIn("Rejected", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_under_review.review_status, Job.REJECTED)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Rejected", mail.outbox[0].body)
+        self.assertEqual("jobs@djangogirls.org", mail.outbox[0].from_email)
+
+    def test_reject_job_for_ready_to_publish_post(self):
+        reject_url = reverse(
+            'admin:reject_job',
+            args=[self.job_ready_to_publish.id]
+        )
+        response = self.client.get(reject_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_ready_to_publish.refresh_from_db()
+        self.assertIn("Rejected", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_ready_to_publish.review_status, Job.REJECTED)
+
+    def test_reject_job_for_published_post(self):
+        reject_url = reverse(
+            'admin:reject_job',
+            args=[self.job_published.id]
+        )
+        response = self.client.get(reject_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_published.refresh_from_db()
+        self.assertIn("Rejected", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_published.review_status, Job.REJECTED)
+        self.assertEqual(self.job_published.published_date, None)
+
+    def test_restore_job_for_rejected_post(self):
+        restore_url = reverse(
+            'admin:restore_job',
+            args=[self.job_rejected.id]
+        )
+        response = self.client.get(restore_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_rejected.refresh_from_db()
+        self.assertIn("Under review", str(response.content))
+        self.assertIn("myemail@test.com", str(response.content))
+        self.assertEqual(self.job_rejected.review_status, Job.UNDER_REVIEW)
+
+    def test_publish_job_for_ready_to_publish_post(self):
+        publish_url = reverse(
+            'admin:publish_job',
+            args=[self.job_ready_to_publish.id]
+        )
+        response = self.client.get(publish_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.job_ready_to_publish.refresh_from_db()
+        self.assertIn("Published", str(response.content))
+        self.assertNotIn("(None)", str(response.content))
+        self.assertEqual(self.job_ready_to_publish.review_status, Job.PUBLISHED)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Published", mail.outbox[0].body)
+        self.assertEqual("jobs@djangogirls.org", mail.outbox[0].from_email)
 
     def tearDown(self):
         self.job_open.delete()
+        self.job_under_review.delete()
+        self.job_ready_to_publish.delete()
+        self.job_rejected.delete()
+        self.job_published.delete()
         self.admin_user.delete()

--- a/jobs/tests/test_admin.py
+++ b/jobs/tests/test_admin.py
@@ -59,6 +59,9 @@ class JobAdminTest(TestCase):
         self.assertEqual(self.job_open.review_status, Job.UNDER_REVIEW)
 
     def test_assigning_job_reviewer_to_under_review_post(self):
+        """This test secures a situation when someone enters the URL manually.
+        If a post is not in the OPEN state, it is not possible to execute
+        the assign method and the app returns Error 400"""
         assign_reviewer_url = reverse(
             'admin:assign_job_reviewer',
             args=[self.job_under_review.id]

--- a/jobs/tests/test_admin.py
+++ b/jobs/tests/test_admin.py
@@ -13,7 +13,8 @@ from jobs.models import Job, Meetup
 
 
 class JobAdminTest(TestCase):
-    """Tests for custom methods of JobAdmin model."""
+    """Tests for custom methods of JobAdmin model. Most importantly
+    the publish flow in admin"""
 
     def setUp(self):
         self.admin_user = User.objects.create_superuser('myemail@test.com', 'example')

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -140,6 +140,20 @@ class JobModelTests(TestCase):
             self.future_date
         )
 
+    def test_publish_expired_post(self):
+        """Tests the publish method with past expiration date. It might happen
+         if the expired post is rejected and than re-published"""
+        self.job_ready_past_exp_date.publish()
+        self.assertTrue(self.job_ready_past_exp_date.published_date)
+        self.assertAlmostEqual(
+            self.job_ready_past_exp_date.published_date,
+            timezone.now(),
+            delta=timedelta(seconds=10)
+        )
+        self.assertTrue(self.job_ready_past_exp_date.expiration_date)
+        result = self.job_ready_past_exp_date.expiration_date - timezone.now()
+        self.assertEqual(result.days, 59)
+
     def test_publish_twice_in_a_row(self):
         """It is not possible to publish a job offer twice"""
         self.assertFalse(self.job_ready_no_exp_date.published_date)

--- a/templates/jobs/email_templates/status.html
+++ b/templates/jobs/email_templates/status.html
@@ -2,9 +2,9 @@
     <body>
         <p>Hello there!</p>
         <p>This is an automatically generated email about your {{ option }}. Current status is: {{ status }}.</p>
-        {% if reviewers_comment %}
+        {% if message_to_organisation %}
             <p>This is your feedback:</p>
-            <p> {{ reviewers_comment|linebreaks }}</p>
+            <p> {{ message_to_organisation|linebreaks }}</p>
         {% else %}
             <p>There was no additional information provided.</p>
         {% endif %}

--- a/templates/jobs/email_templates/status.txt
+++ b/templates/jobs/email_templates/status.txt
@@ -2,9 +2,9 @@ Hello there!
 
 This is an automatically generated email about your {{ option }}. Current status is: {{ status }}.
 
-{% if reviewers_comment %}
+{% if message_to_organisation %}
 This is your feedback:
-{{ reviewers_comment|linebreaks }}
+{{ message_to_organisation|linebreaks }}
 {% else %}
 There was no additional information provided.
 {% endif %}


### PR DESCRIPTION
I've added the 'message_to_organisation' field and set it to be sent in emails to organisations/companies that posted on offer.
I've also renamed the 'reviewer_comment' field to 'internal_comment'.
I've added the help_text to both those fields.

I've also added basic tests for post flow in admin and added error handling in case somebody will enter the URL manually.
