### PR TITLE
Edited some phrasing, changed link

### DIFF
--- a/templates/jobs/job_edit.html
+++ b/templates/jobs/job_edit.html
@@ -35,9 +35,8 @@
             </p>
             <p>
                 Publishing an offer here is free, however, Django Girls is a non-profit organisation
-                with a mission to show more women how amazing programming is. It’d be greatly appreciated if you could
-                consider donating money to us to help us make a bigger impact.
-                You can do so via <a href="https://www.patreon.com/djangogirls">Patreon</a>.
+                with a mission to show more women how amazing programming is. We would appreciate it if you would
+                consider <a href="https://www.patreon.com/djangogirls">making a donation through Patreon</a> to help us make a bigger impact.
             </p>
         </div>
             <div class="panel panel-feature-blue">


### PR DESCRIPTION
I feel like the link to donate should be in the call to action, so I added it there, and removed the other link. Feel free to reject if you disagree. The reason I did this is that when I saw this on the page, I totally missed the next sentence. My brain expected the "make a donation" text to be a link, and when it wasn't one, I stopped reading.
