### PR TITLE
Fixed #49, added Recurrence field to form and clearing up

### DIFF
--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -44,6 +44,7 @@ class MeetupForm(forms.ModelForm):
         widget=DateTimePicker(options={"format": "YYYY-MM-DD HH:mm",
                                        "pickSeconds": False}))
     meetup_end_date = forms.DateTimeField(
+        required=False,
         widget=DateTimePicker(options={"format": "YYYY-MM-DD HH:mm",
                                        "pickSeconds": False}))
     description = forms.CharField(widget=CKEditorWidget())

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -155,7 +155,7 @@ class JobModelTests(TestCase):
         self.assertEqual(result.days, 59)
 
     def test_publish_twice_in_a_row(self):
-        """It is not possible to publish a job offer twice"""
+        """It is not possible to publish a job opportunity twice"""
         self.assertFalse(self.job_ready_no_exp_date.published_date)
         self.job_ready_no_exp_date.publish()
         self.assertTrue(self.job_ready_no_exp_date.published_date, "Job has no published date.")

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -41,7 +41,7 @@ class MainPageTests(TestCase):
     def test_main_page_with_empty_database(self):
         response = self.client.get(reverse('jobs:main'))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("No job offers yet", str(response.content))
+        self.assertIn("No job opportunities yet", str(response.content))
         self.assertIn("No meetups yet", str(response.content))
 
 
@@ -51,7 +51,7 @@ class JobsPageTests(TestCase):
         response = self.client.get(reverse('jobs:jobs'))
         self.assertEqual(response.status_code, 200)
         self.assertIn(
-            "There are no job offers at this moment.", str(response.content)
+            "There are no job opportunities at this moment.", str(response.content)
         )
 
     def test_jobs_page_with_job_not_ready_to_publish(self):
@@ -62,7 +62,7 @@ class JobsPageTests(TestCase):
         response = self.client.get(reverse('jobs:jobs'))
         self.assertEqual(response.status_code, 200)
         self.assertIn(
-            "There are no job offers at this moment.", str(response.content)
+            "There are no job opportunities at this moment.", str(response.content)
         )
 
     def test_jobs_page_with_job_ready_to_publish(self):

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -80,7 +80,7 @@ def confirm_submission(request):
 
 def create_job(request):
     job_form = JobForm()
-    success_message = 'Your job offer was added to our database, \
+    success_message = 'Your job opportunity was added to our database, \
                     you will receive further information shortly.'
     if request.method == 'POST':
         job_form = JobForm(request.POST)

--- a/templates/global/footer.html
+++ b/templates/global/footer.html
@@ -24,7 +24,7 @@
             <div class="col-md-2">
                 <p><a href="{% url 'jobs:main' %}">Community</a></p>
                 <ul>
-                    <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
+                    <li><a href="{% url 'jobs:jobs' %}">Job opportunities</a></li>
                     <li><a href="{% url 'jobs:meetups' %}">Meetups</a></li>
                     <li><a href="http://facebook.com/djangogirls">Facebook</a></li>
                     <li><a href="http://twitter.com/djangogirls">Twitter</a></li>
@@ -48,7 +48,7 @@
                 <ul>
                     <li><b>{{ future_events_count }}</b> upcoming events</li>
                     <li><b>{{ past_events_count }}</b> past events</li>
-                    <!--- tags to do for meetups and job offers
+                    <!--- tags to do for meetups and job opportunities
                     <li><b></b> upcoming meetups</li>-->
                     <li><b>{{ applicants_sum|default_if_none:'0' }}</b> applicants</li>
                     <li><b>{{ attendees_sum|default_if_none:'0' }}</b> attendees</li>

--- a/templates/includes/_jobs_intro.html
+++ b/templates/includes/_jobs_intro.html
@@ -1,7 +1,10 @@
 <p>
    Working as a software developer is a great way to become one.
    There are lots of companies out there who are hiring,
-   but how can you tell which ones are supportive? Here, you can find opportunities with companies
+   but how can you tell which ones are supportive?
+</p>
+<p>
+   Here, you can find opportunities with companies
    who hire beginners and want to train them. They’re not targeting only women,
    but they do care about diversity in the workplace. We trust they do the right thing.
 </p>

--- a/templates/includes/_meetups_intro.html
+++ b/templates/includes/_meetups_intro.html
@@ -1,5 +1,9 @@
-<p>Did you know that Dori, Django Girls alumni from our first event in Berlin,
-got a job because she gave a talk about Django Girls at her local Django meetup in Budapest?
-That’s why your local meetups and user groups can help you make a career in tech.
-Here you can find (or add!) meetups in your city where programmers meet to talk about technology.
-They all have published Code of Conduct, we checked!</p>
+<p>
+    Did you know that Dori, Django Girls alumni from our first event in Berlin,
+    got a job because she gave a talk about Django Girls at her local Django meetup in Budapest?
+    That’s why your local meetups and user groups can help you make a career in tech.
+</p>
+<p>
+    Here you can find (or add!) meetups in your city where programmers meet to talk about technology.
+    They all have published Code of Conduct, we checked!
+</p>

--- a/templates/jobs/confirm_submission.html
+++ b/templates/jobs/confirm_submission.html
@@ -6,14 +6,17 @@
         <div class="row">
             <div class="col-md-12">
                 {% include 'includes/_info_messages.html' %}
-                <h3 class="text-success">Yay, high-five! Thank you for adding a job offer/meetup.</h3>
+                <h3 class="text-success">Yay, high-five! Thank you for adding a job opportunity/meetup.</h3>
                 <hr/>
                 <p> 
-                    We carefully review each offer and meetup. We will get in touch with you shortly. 
+                    We carefully review each job opportunity and meetup. We will get in touch with you shortly.
                     
                 </p>
                 <p>
-                    Would you help us out too? We don’t charge for helping you reach people who may be interested in your job offer/meetup. However, we are a non-profit organisation with a mission to show more women the joy of programming. Consider making a <a href="https://www.patreon.com/djangogirls">small donation</a> to help us make a larger impact on the world.
+                    Would you help us out too? We don’t charge for helping you reach people
+                    who may be interested in your job opportunity/meetup. However, we are a non-profit organisation
+                    with a mission to show more women the joy of programming.
+                    Consider making a <a href="https://www.patreon.com/djangogirls">small donation</a> to help us make a larger impact on the world.
                 </p>
                 <p>
                     <strong>Thank you!</strong>

--- a/templates/jobs/job_details.html
+++ b/templates/jobs/job_details.html
@@ -4,51 +4,51 @@
 
 {% block content %}
 
-    <section id="job_details">
-        <div class="container">
-            <div class="row">
-
-                <div class="col-md-12">
-                    <ol class="breadcrumb">
-                        <li><a href="{% url 'core:index' %}">Home</a></li>
-                        <li><a href="{% url 'jobs:main' %}">Community</a></li>
-                        <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
-                        <li class="active">{{ job.title }}</li>
-                    </ol>
-                    <div class="page-header">
-                        <h3>{{ job.title }} <small>at {{ job.company }}</small></h3>
+<section id="job_details">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                
+                <ol class="breadcrumb">
+                    <li><a href="{% url 'core:index' %}">Home</a></li>
+                    <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                    <li><a href="{% url 'jobs:jobs' %}">Job opportunities</a></li>
+                    <li class="active">{{ job.title }}</li>
+                </ol>
+                <div class="page-header">
+                    <h3>{{ job.title }} <small>at {{ job.company }}</small></h3>
+                </div>
+                <div class="panel panel-feature-blue">
+                    <div class="panel-heading">
                     </div>
-                    <div class="panel panel-feature-blue">
-                        <div class="panel-heading">
+                    <div class="panel-body">
+                        <div class="text-muted pull-right">
+                            <p>Published on {{ job.published_date|date:'d F Y' }}</p>
+                            <table class="table" id="job-table">
+                                <tr>
+                                    <td>Remote work</td>
+                                    <td><strong>{{ job.remote_work|yesno }}</strong></td>
+                                </tr>
+                                <tr>
+                                    <td>Relocation offered</td>
+                                    <td><strong>{{ job.relocation|yesno }}</strong></td>
+                                </tr>
+                            </table>
                         </div>
-                        <div class="panel-body">
-                            <div class="text-muted pull-right">
-                                <p>Published on {{ job.published_date|date:'d F Y' }}</p>
-                                <table class="table" id="job-table">
-                                    <tr>
-                                        <td>Remote work</td>
-                                        <td><strong>{{ job.remote_work|yesno }}</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Relocation offered</td>
-                                        <td><strong>{{ job.relocation|yesno }}</strong></td>
-                                    </tr>
-                                </table>
-                            </div>
-                            <h4>Where</h4>
-                            <p>{{ job.cities }} ({{ job.country }})</p>
-                            <h4>Description</h4>
-                            <p>{{ job.description|safe }}</p>
-                            <h4>Contact</h4>
-                            <p>{{ job.contact_email|urlize }}</p>
-                            <p><a href="{{ job.website }}">view website</a></p>
-                        </div>
+                        <h4>Where</h4>
+                        <p>{{ job.cities }} ({{ job.country }})</p>
+                        <h4>Description</h4>
+                        <p>{{ job.description|safe }}</p>
+                        <h4>Contact</h4>
+                        <p>{{ job.contact_email|urlize }}</p>
+                        <p><a href="{{ job.website }}">view website</a></p>
                     </div>
+                </div>
 
-                </div> <!--.col-md-12-->
-            </div> <!--.row-->
-        </div> <!--.container-->
-    </section> <!--#job_details-->
+            </div> <!--.col-md-12-->
+        </div> <!--.row-->
+    </div> <!--.container-->
+</section> <!--#job_details-->
 
 
 {% endblock content %}

--- a/templates/jobs/job_edit.html
+++ b/templates/jobs/job_edit.html
@@ -13,22 +13,22 @@
          <ol class="breadcrumb">
             <li><a href="{% url 'core:index' %}">Home</a></li>
             <li><a href="{% url 'jobs:main' %}">Community</a></li>
-            <li><a href="{% url 'jobs:jobs' %}">Job offers</a></li>
-            <li class="active">Add job offer</li>
+            <li><a href="{% url 'jobs:jobs' %}">Job opportunities</a></li>
+            <li class="active">Add job opportunity</li>
         </ol>
         <div>
             <h2>
-                Add job offer
+                Add job opportunity
             </h2>
             <hr/>
             <p>
                 Adding a job opportunity on Django Girls website is free. Yay!
                 Our website is visited by many enthusiastic beginner developers and we can help you reach them with your offer.
-                However, all the offers listed here need to meet following requirements:
+                However, all the opportunities listed here need to meet following requirements:
             </p>
             <ul>
-                <li>The offer needs to be beginner-friendly - no experience required.</li>
-                <li>The offer must not discriminate any gender.</li>
+                <li>The opportunity needs to be beginner-friendly - no experience required.</li>
+                <li>The opportunity must not discriminate any gender.</li>
             </ul>
             <p>
                 By submitting a job opportunity to us, you're demonstrating that you care about diversity in your workplace and in the tech community in general.
@@ -36,7 +36,7 @@
             </p>
             <br/>
             <p class="text-info">
-                Publishing an offer here is free, however, Django Girls is a non-profit organisation
+                Publishing a job opportunity here is free, however, Django Girls is a non-profit organisation
                 with a mission to show more women how amazing programming is. We would appreciate it if you would
                 consider <a href="https://www.patreon.com/djangogirls">making a donation through Patreon</a> to help us make a bigger impact.
             </p>
@@ -44,7 +44,7 @@
         </div>
             <div class="panel panel-feature-blue">
                 <div class="panel-heading">
-                    <h2>New offer</h2>
+                    <h2>New job opportunity</h2>
                 </div>
                 <div class="panel-body">
                     <form method="POST" class="job-form">

--- a/templates/jobs/jobs.html
+++ b/templates/jobs/jobs.html
@@ -13,22 +13,23 @@
                         <li class="active">Job opportunities</li>
                     </ol>
                     <h2>
-                        Job offers
+                        Job opportunities
                     </h2>
 
                     <hr/>
                       {% include 'includes/_jobs_intro.html' %}
+
                     <p class="text-info">
                        On this page, we only list opportunities that require no experience from companies who
                        want to hire beginners and care about diversity.
                     </p>
-                    <a class="btn btn-blue" href="{% url 'jobs:job_new' %}">Add offer</a>
+                    <a class="btn btn-blue" href="{% url 'jobs:job_new' %}">Add opportunity</a>
                 </div> <!--.col-md-12-->
             </div> <!--.row-->
 
             <div class="row">
                 <div class="col-md-12">
-                    <h3>Offers</h3>
+                    <h3>Open opportunities</h3>
                     <table class="table table-striped">
                         <thead>
                             <th>Company</th>
@@ -52,7 +53,7 @@
                                 </tr>
                             {% empty %}
                                 <tr>
-                                    <td>There are no job offers at this moment.</td>
+                                    <td>There are no job opportunities at this moment.</td>
                                 </tr>
                             {% endfor %}
                         </tbody>

--- a/templates/jobs/main.html
+++ b/templates/jobs/main.html
@@ -43,13 +43,15 @@
                     </div>
                     <div class="panel-body">
                           {% include 'includes/_jobs_intro.html' %}
-                        <h4>Recent offers:</h4>
+                        <br/>
+                        <h4>Recent opportunities:</h4>
+                        <hr/>
                         {% if job_offers %}
                             {% for job in job_offers %}
                                 {% include 'includes/_jobs.html' with job=job %}
                             {% endfor %}
                         {% else %}
-                            <p>No job offers yet...</p>
+                            <p>No job opportunities yet...</p>
                         {% endif %}
                             <a class="btn btn-blue btn-block" href="{% url 'jobs:jobs' %}">More...</a>
                     </div>
@@ -62,7 +64,9 @@
                     </div>
                     <div class="panel-body">
                           {% include 'includes/_meetups_intro.html' %}
+                        <br/>
                         <h4>Recent meetups:</h4>
+                        <hr/>
                         {% if meetup_list %}
                             {% for meetup in meetup_list %}
                                 {% include 'includes/_meetups.html' with meetup=meetup %}

--- a/templates/jobs/meetup_details.html
+++ b/templates/jobs/meetup_details.html
@@ -30,6 +30,7 @@
                     </div>
                     <div class="panel-body">
                         <div class="text-muted pull-right">
+                            <p>{{ meetup.get_meetup_type_display }}</p>
                             <p>Published on {{ meetup.published_date|date:'d F Y' }}</p>
                         </div>
                         <h4>When</h4>
@@ -44,7 +45,7 @@
                         <h4>Description</h4>
                         <p>{{ meetup.description|safe }}</p>
                         {% if meetup.is_recurring %}
-                            <p>This is a recurring event</p>
+                            <p><strong>This is a recurring event:</strong> {{ meetup.recurrence }}</p>
                         {% endif %}
                         {% if meetup.organisation %}
                             <h4>Organised by</h4>

--- a/templates/jobs/meetups.html
+++ b/templates/jobs/meetups.html
@@ -4,46 +4,47 @@
 {% block content %}
 
     <div class="container">
-
         <section id="meetups">
-            <ol class="breadcrumb">
-                <li><a href="{% url 'core:index' %}">Home</a></li>
-                <li><a href="{% url 'jobs:main' %}">Community</a></li>
-                <li class="active">Meetups</li>
-            </ol>
-        {% include 'includes/_info_messages.html' %}
-            <h2>
-                Meetups
-            </h2>
+            <div class="row">
+                <div class="col-md-12">
+                    <ol class="breadcrumb">
+                        <li><a href="{% url 'core:index' %}">Home</a></li>
+                        <li><a href="{% url 'jobs:main' %}">Community</a></li>
+                        <li class="active">Meetups</li>
+                    </ol>
+                    <h2>
+                        Meetups
+                    </h2>
 
+                    <hr/>
+                    {% include 'includes/_meetups_intro.html' %}
 
-            <hr/>
-            {% include 'includes/_meetups_intro.html' %}
-            <br/>
-            <p class="text-info">
-                On this page we only list meetups and groups that are friendly to beginners
-                and have a published Code of Conduct. If you see a meetup that doesn’t meet the requirement,
-                please do let us know. We care about you.
-            </p>
+                    <p class="text-info">
+                        On this page we only list meetups and groups that are friendly to beginners
+                        and have a published Code of Conduct. If you see a meetup that doesn’t meet the requirement,
+                        please do let us know. We care about you.
+                    </p>
+                    <a class="btn" href="{% url 'jobs:meetup_new' %}">Add meetup</a>
+                </div> <!--.col-md-12-->
+            </div> <!--.row-->
 
-        <a class="btn" href="{% url 'jobs:meetup_new' %}">Add meetup</a>
+            <div class="row">
+                <div class="col-md-12">
+                    <h3>
+                        Upcoming meetups
+                    </h3>
+                </div> <!-- /.col-md-12 -->
+            </div> <!-- /.row -->
+
+            <div class="row">
+                {% for meetup in meetup_list %}
+                    <div class="col-md-4 event">
+                        {% include 'includes/_meetups.html' with meetup=meetup %}
+                    </div>
+                    {% if forloop.counter|divisibleby:3 %}</div><div class="row">{% endif %}
+                {% endfor %}
+            </div> <!-- /.row -->
         </section>
-        <div class="row">
-            <div class="col-md-12">
-                <h2>
-                    Upcoming meetups
-                </h2>
-            </div> <!-- /.col-md-12 -->
-        </div> <!-- /.row -->
-
-        <div class="row">
-            {% for meetup in meetup_list %}
-                <div class="col-md-4 event">
-                    {% include 'includes/_meetups.html' with meetup=meetup %}
-                </div>
-                {% if forloop.counter|divisibleby:3 %}</div><div class="row">{% endif %}
-            {% endfor %}
-        </div> <!-- /.row -->
     </div> <!-- /.container -->
 
 {% endblock %}


### PR DESCRIPTION
I've changed all job offers to opportunities.
I've also added the Recurrence field to the Add meetup form - we somehow missed that out.
I've added the meetup_type and recurrence to meetup_details - we didn't display them.
General cleaning up so jobs pages are similar in style and format with meetup pages.
